### PR TITLE
feat(IDREFS): add support for IDREFS attributes

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -289,11 +289,26 @@ ElementHandler.prototype.createElement = function(node) {
     var prop = descriptor.propertiesByName[name];
 
     if (prop && prop.isReference) {
-      context.addReference({
-        element: instance,
-        property: prop.ns.name,
-        id: value
-      });
+
+      if (!prop.isMany) {
+        context.addReference({
+          element: instance,
+          property: prop.ns.name,
+          id: value
+        });
+      }
+      else {
+        // IDREFS is a whitespace-separated list of references.
+        var values = value.split(' ');
+        forEach(values, function (v) {
+          context.addReference({
+            element: instance,
+            property: prop.ns.name,
+            id: v
+          });
+        });
+      }
+
     } else {
       if (prop) {
         value = coerceType(prop.type, value);
@@ -555,6 +570,7 @@ XMLReader.prototype.fromXML = function(xml, rootHandler, done) {
           // remove unresolvable reference
           collection.splice(idx, 1);
         } else {
+          idx = idx > -1 ? idx : collection.length;
           // update reference
           collection[idx] = reference;
         }

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -421,7 +421,19 @@ ElementSerializer.prototype.parseAttributes = function(properties) {
     var value = element.get(p.name);
 
     if (p.isReference) {
-      value = value.id;
+
+      if (!p.isMany) {
+        value = value.id;
+      }
+      else {
+        var values = [];
+        forEach(value, function(v) {
+          values.push(v.id);
+        });
+        // IDREFS is a whitespace-separated list of references.
+        value = values.join(' ');
+      }
+
     }
 
     self.addAttribute(self.nsAttributeName(p), value);

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -190,6 +190,19 @@
           "isMany": true
         }
       ]
+    },
+    {
+      "name": "AttributeReferenceCollection",
+      "superClass": [ "BaseWithId" ],
+      "properties": [
+        {
+          "name": "refs",
+          "type": "Complex",
+          "isReference": true,
+          "isMany": true,
+          "isAttr": true
+        }
+      ]
     }
   ]
 }

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -646,6 +646,52 @@ describe('Reader', function() {
         });
       });
 
+
+      it('attribute collection', function(done) {
+
+        // given
+        var reader = new Reader(extendedModel);
+        var rootHandler = reader.handler('props:Root');
+
+        var xml =
+          '<props:root xmlns:props="http://properties">' +
+            '<props:containedCollection id="C_5">' +
+              '<props:complex id="C_1" />' +
+              '<props:complex id="C_2" />' +
+            '</props:containedCollection>' +
+            '<props:attributeReferenceCollection id="C_4" refs="C_2 C_5" />' +
+          '</props:root>';
+
+        // when
+        reader.fromXML(xml, rootHandler, function(err, result) {
+
+          // then
+          expect(result).to.jsonEqual({
+            $type: 'props:Root',
+            any: [
+              {
+                $type: 'props:ContainedCollection',
+                id: 'C_5',
+                children: [
+                  { $type: 'props:Complex', id: 'C_1' },
+                  { $type: 'props:Complex', id: 'C_2' }
+                ]
+              },
+              { $type: 'props:AttributeReferenceCollection', id: 'C_4' }
+            ]
+          });
+
+          var containedCollection = result.any[0];
+          var complex_c2 = containedCollection.children[1];
+
+          var attrReferenceCollection = result.any[1];
+
+          expect(attrReferenceCollection.refs).to.jsonEqual([ complex_c2, containedCollection ]);
+
+          done(err);
+        });
+      });
+
     });
 
   });

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -694,6 +694,26 @@ describe('Writer', function() {
           '</props:referencingCollection>');
       });
 
+
+      it('attribute collection', function() {
+
+        // given
+        var writer = createWriter(model);
+
+        var complexCount = model.create('props:ComplexCount', { id: 'ComplexCount_1' });
+        var complexNesting = model.create('props:ComplexNesting', { id: 'ComplexNesting_1' });
+
+        var attrReferenceCollection = model.create('props:AttributeReferenceCollection', {
+          refs: [ complexCount, complexNesting ]
+        });
+
+        // when
+        var xml = writer.toXML(attrReferenceCollection);
+
+        // then
+        expect(xml).to.eql('<props:attributeReferenceCollection xmlns:props="http://properties" refs="ComplexCount_1 ComplexNesting_1" />');
+      });
+
     });
   });
 


### PR DESCRIPTION
The CMMN schema (still) contains elements with `IDREFS` attributes.

According to [1] `IDREFS` represents a whitespace-separated list of references to identifiers.

This pull request adds support for `IDREFS` attributes.

[1]: http://books.xmlschemata.org/relaxng/ch19-77167.html