### PR TITLE
Replace sax-js with saxen for XML parsing

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -694,6 +694,11 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
 
       var attrs = obj.attrs;
 
+      // saxen may return attrs=true if no attributes were parsed :-(
+      if (attrs === true) {
+        attrs = {};
+      }
+
       var decodedAttrs = Object.keys(attrs).reduce(function(d, key) {
         var value = decodeStr(attrs[key]);
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -1,13 +1,12 @@
 'use strict';
 
-var reduce = require('lodash/collection/reduce'),
-    forEach = require('lodash/collection/forEach'),
+var forEach = require('lodash/collection/forEach'),
     find = require('lodash/collection/find'),
     assign = require('lodash/object/assign'),
     defer = require('lodash/function/defer');
 
 var Stack = require('tiny-stack'),
-    SaxParser = require('sax').parser,
+    SaxParser = require('saxen'),
     Moddle = require('moddle'),
     parseNameNs = require('moddle/lib/ns').parseName,
     Types = require('moddle/lib/types'),
@@ -15,85 +14,29 @@ var Stack = require('tiny-stack'),
     isSimpleType = Types.isSimple,
     common = require('./common'),
     XSI_TYPE = common.XSI_TYPE,
-    XSI_URI = common.DEFAULT_NS_MAP.xsi,
     serializeAsType = common.serializeAsType,
     aliasToName = common.aliasToName;
 
-function parseNodeAttributes(node) {
-  var nodeAttrs = node.attributes;
 
-  return reduce(nodeAttrs, function(result, v, k) {
-    var name, ns;
+function normalizeTypeName(name, model) {
 
-    if (!v.local) {
-      name = v.prefix;
-    } else {
-      ns = parseNameNs(v.name, v.prefix);
-      name = ns.name;
-    }
+  var nameNs = parseNameNs(name);
+  var pkg = model.getPackage(nameNs.prefix);
 
-    result[name] = v.value;
-    return result;
-  }, {});
-}
+  var typePrefix = pkg.xml && pkg.xml.typePrefix;
 
-function normalizeType(node, attr, model) {
-  var nameNs = parseNameNs(attr.value);
-
-  var uri = node.ns[nameNs.prefix || ''],
-      localName = nameNs.localName,
-      pkg = uri && model.getPackage(uri),
-      typePrefix;
-
-  if (pkg) {
-    typePrefix = pkg.xml && pkg.xml.typePrefix;
-
-    if (typePrefix && localName.indexOf(typePrefix) === 0) {
-      localName = localName.slice(typePrefix.length);
-    }
-
-    attr.value = pkg.prefix + ':' + localName;
-  }
-}
-
-/**
- * Normalizes namespaces for a node given an optional default namespace and a
- * number of mappings from uris to default prefixes.
- *
- * @param  {XmlNode} node
- * @param  {Model} model the model containing all registered namespaces
- * @param  {Uri} defaultNsUri
- */
-function normalizeNamespaces(node, model, defaultNsUri) {
-  var uri, prefix;
-
-  uri = node.uri || defaultNsUri;
-
-  if (uri) {
-    var pkg = model.getPackage(uri);
-
-    if (pkg) {
-      prefix = pkg.prefix;
-    } else {
-      prefix = node.prefix;
-    }
-
-    node.prefix = prefix;
-    node.uri = uri;
+  if (!typePrefix) {
+    return name;
   }
 
-  forEach(node.attributes, function(attr) {
+  var localName = nameNs.localName;
 
-    // normalize xsi:type attributes because the
-    // assigned type may or may not be namespace prefixed
-    if (attr.uri === XSI_URI && attr.local === 'type') {
-      normalizeType(node, attr, model);
-    }
-
-    normalizeNamespaces(attr, model, null);
-  });
+  if (localName.indexOf(typePrefix) === 0) {
+    return nameNs.prefix + ':' + localName.slice(typePrefix.length);
+  } else {
+    return name;
+  }
 }
-
 
 function error(message) {
   return new Error(message);
@@ -324,7 +267,7 @@ ElementHandler.prototype.handleEnd = function() {
  * @param  {Element} node the xml node
  */
 ElementHandler.prototype.createElement = function(node) {
-  var attributes = parseNodeAttributes(node),
+  var attributes = node.attributes,
       Type = this.type,
       descriptor = getModdleDescriptor(Type),
       context = this.context,
@@ -370,7 +313,7 @@ ElementHandler.prototype.createElement = function(node) {
 
 ElementHandler.prototype.getPropertyForNode = function(node) {
 
-  var nameNs = parseNameNs(node.local, node.prefix);
+  var nameNs = parseNameNs(node.name);
 
   var type = this.type,
       model = this.model,
@@ -379,23 +322,23 @@ ElementHandler.prototype.getPropertyForNode = function(node) {
   var propertyName = nameNs.name,
       property = descriptor.propertiesByName[propertyName],
       elementTypeName,
-      elementType,
-      typeAnnotation;
+      elementType;
 
   // search for properties by name first
 
   if (property) {
 
     if (serializeAsType(property)) {
-      typeAnnotation = node.attributes[XSI_TYPE];
+      elementTypeName = node.attributes[XSI_TYPE];
 
       // xsi type is optional, if it does not exists the
       // default type is assumed
-      if (typeAnnotation) {
+      if (elementTypeName) {
 
-        elementTypeName = typeAnnotation.value;
+        // take possible type prefixes from XML
+        // into account, i.e.: xsi:type="t{ActualType}"
+        elementTypeName = normalizeTypeName(elementTypeName, model);
 
-        // TODO: extract real name from attribute
         elementType = model.getType(elementTypeName);
 
         return assign({}, property, { effectiveType: getModdleDescriptor(elementType).name });
@@ -516,8 +459,9 @@ GenericElementHandler.prototype = Object.create(BaseElementHandler.prototype);
 GenericElementHandler.prototype.createElement = function(node) {
 
   var name = node.name,
-      prefix = node.prefix,
-      uri = node.ns[prefix],
+      ns = parseNameNs(name),
+      prefix = ns.prefix,
+      uri = node.ns[prefix + '$uri'],
       attributes = node.attributes;
 
   return this.model.createAny(name, uri, attributes);
@@ -601,7 +545,7 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
       lax = this.lax;
 
   var context = new Context(assign({}, options, { rootHandler: rootHandler })),
-      parser = new SaxParser(true, { xmlns: true, trim: true }),
+      parser = new SaxParser({ proxy: true }),
       stack = new Stack();
 
   rootHandler.context = context;
@@ -610,6 +554,57 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
   stack.push(rootHandler);
 
 
+  /**
+   * Handle error.
+   *
+   * @param  {Error} err
+   * @param  {Function} getContext
+   * @param  {boolean} lax
+   *
+   * @return {boolean} true if handled
+   */
+  function handleError(err, getContext, lax) {
+
+    var ctx = getContext();
+
+    var line = ctx.line,
+        column = ctx.column,
+        data = ctx.data;
+
+    // we receive the full context data here,
+    // for elements trim down the information
+    // to the tag name, only
+    if (data.charAt(0) === '<' && data.indexOf(' ') !== -1) {
+      data = data.slice(0, data.indexOf(' ')) + '>';
+    }
+
+    var message =
+      'unparsable content ' + (data ? data + ' ' : '') + 'detected\n\t' +
+        'line: ' + line + '\n\t' +
+        'column: ' + column + '\n\t' +
+        'nested error: ' + err.message;
+
+    if (lax) {
+      context.addWarning({
+        message: message,
+        error: err
+      });
+
+      console.warn('could not parse node');
+      console.warn(err);
+
+      return true;
+    } else {
+      console.error('could not parse document');
+      console.error(err);
+
+      throw error(message);
+    }
+  }
+
+  /**
+   * Resolve collected references on parse end.
+   */
   function resolveReferences() {
 
     var elementsById = context.elementsById;
@@ -654,43 +649,19 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     }
   }
 
-  function handleClose(tagName) {
+  function handleClose() {
     stack.pop().handleEnd();
   }
 
-  function handleOpen(node) {
+  function handleOpen(node, getContext) {
     var handler = stack.peek();
-
-    normalizeNamespaces(node, model);
 
     try {
       stack.push(handler.handleNode(node));
-    } catch (e) {
+    } catch (err) {
 
-      var line = this.line,
-          column = this.column;
-
-      var message =
-        'unparsable content <' + node.name + '> detected\n\t' +
-          'line: ' + line + '\n\t' +
-          'column: ' + column + '\n\t' +
-          'nested error: ' + e.message;
-
-      if (lax) {
-        context.addWarning({
-          message: message,
-          error: e
-        });
-
-        console.warn('could not parse node');
-        console.warn(e);
-
+      if (handleError(err, getContext, lax)) {
         stack.push(new NoopHandler());
-      } else {
-        console.error('could not parse document');
-        console.error(e);
-
-        throw error(message);
       }
     }
   }
@@ -699,10 +670,39 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     stack.peek().handleText(text);
   }
 
-  parser.onopentag = handleOpen;
-  parser.oncdata = parser.ontext = handleText;
-  parser.onclosetag = handleClose;
-  parser.onend = resolveReferences;
+  var uriMap = model.getPackages().reduce(function(uriMap, p) {
+    uriMap[p.uri] = p.prefix;
+
+    return uriMap;
+  }, {});
+
+  parser
+    .ns(uriMap)
+    .on('openTag', function(obj, decodeStr, selfClosing, getContext) {
+
+      var attrs = obj.attrs;
+
+      var decodedAttrs = Object.keys(attrs).reduce(function(d, key) {
+        var value = decodeStr(attrs[key]);
+
+        d[key] = value;
+
+        return d;
+      }, {});
+
+      var node = {
+        name: obj.name,
+        originalName: obj.originalName,
+        attributes: decodedAttrs,
+        ns: obj.ns
+      };
+
+      handleOpen(node, getContext);
+    })
+    .on('closeTag', handleClose)
+    .on('cdata', handleText)
+    .on('text', handleText)
+    .on('error', handleError);
 
   // deferred parse XML to make loading really ascnchronous
   // this ensures the execution environment (node or browser)
@@ -712,7 +712,9 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     var error;
 
     try {
-      parser.write(xml).close();
+      parser.parse(xml);
+
+      resolveReferences();
     } catch (e) {
       error = e;
     }

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -666,7 +666,19 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     }
   }
 
+  function handleCData(text) {
+    stack.peek().handleText(text);
+  }
+
   function handleText(text) {
+    // strip whitespace only nodes, i.e. before
+    // <!CDATA[ ... ]> sections and in between tags
+    text = text.trim();
+
+    if (!text) {
+      return;
+    }
+
     stack.peek().handleText(text);
   }
 
@@ -700,7 +712,7 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
       handleOpen(node, getContext);
     })
     .on('closeTag', handleClose)
-    .on('cdata', handleText)
+    .on('cdata', handleCData)
     .on('text', handleText)
     .on('error', handleError);
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -602,6 +602,11 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     }
   }
 
+  function handleWarning(err, getContext) {
+    // just like handling errors in <lax=true> mode
+    return handleError(err, getContext, true);
+  }
+
   /**
    * Resolve collected references on parse end.
    */
@@ -692,12 +697,8 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     .ns(uriMap)
     .on('openTag', function(obj, decodeStr, selfClosing, getContext) {
 
-      var attrs = obj.attrs;
-
-      // saxen may return attrs=true if no attributes were parsed :-(
-      if (attrs === true) {
-        attrs = {};
-      }
+      // gracefully handle unparsable attributes (attrs=false)
+      var attrs = obj.attrs || {};
 
       var decodedAttrs = Object.keys(attrs).reduce(function(d, key) {
         var value = decodeStr(attrs[key]);
@@ -719,7 +720,8 @@ XMLReader.prototype.fromXML = function(xml, options, done) {
     .on('closeTag', handleClose)
     .on('cdata', handleCData)
     .on('text', handleText)
-    .on('error', handleError);
+    .on('error', handleError)
+    .on('warn', handleWarning);
 
   // deferred parse XML to make loading really ascnchronous
   // this ensures the execution environment (node or browser)

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -57,7 +57,7 @@ function getNsAttrs(namespaces) {
 
 function getElementNs(ns, descriptor) {
   if (descriptor.isGeneric) {
-    return descriptor.name;
+    return assign({ localName: descriptor.ns.localName }, ns);
   } else {
     return assign({ localName: nameToAlias(descriptor.ns.localName, descriptor.$pkg) }, ns);
   }
@@ -469,17 +469,20 @@ ElementSerializer.prototype.logNamespaceUsed = function(ns) {
   //
   //   * prefix only
   //   * prefix:uri
+  //   * localName only
 
-  var prefix = ns.prefix;
+  var prefix = ns.prefix,
+      uri = ns.uri,
+      wellknownUri;
 
-  // graceful handle anonymous (non-ns) elements, cf. #23
-  if (typeof prefix === 'undefined') {
-    return {};
+  // handle anonymous namespaces (elementForm=unqualified), cf. #23
+  if (!prefix && !uri) {
+    return { localName: ns.localName };
   }
 
-  var wellknownUri = DEFAULT_NS_MAP[prefix] || model && (model.getPackage(prefix) || {}).uri;
+  wellknownUri = DEFAULT_NS_MAP[prefix] || model && (model.getPackage(prefix) || {}).uri;
 
-  var uri = ns.uri || namespaces.prefixMap[prefix] || wellknownUri;
+  uri = uri || namespaces.prefixMap[prefix] || wellknownUri;
 
   if (!uri) {
     throw new Error('no namespace uri given for prefix <' + ns.prefix + '>');

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -473,6 +473,7 @@ ElementSerializer.prototype.logNamespaceUsed = function(ns) {
 
   var prefix = ns.prefix,
       uri = ns.uri,
+      newPrefix, idx,
       wellknownUri;
 
   // handle anonymous namespaces (elementForm=unqualified), cf. #23
@@ -482,16 +483,24 @@ ElementSerializer.prototype.logNamespaceUsed = function(ns) {
 
   wellknownUri = DEFAULT_NS_MAP[prefix] || model && (model.getPackage(prefix) || {}).uri;
 
-  uri = uri || namespaces.prefixMap[prefix] || wellknownUri;
+  uri = uri || wellknownUri || namespaces.prefixMap[prefix];
 
   if (!uri) {
-    throw new Error('no namespace uri given for prefix <' + ns.prefix + '>');
+    throw new Error('no namespace uri given for prefix <' + prefix + '>');
   }
 
   ns = namespaces.uriMap[uri];
 
   if (!ns) {
-    ns = this.logNamespace({ prefix: prefix, uri: uri }, wellknownUri);
+    newPrefix = prefix;
+    idx = 1;
+
+    // find a prefix that is not mapped yet
+    while (namespaces.prefixMap[newPrefix]) {
+      newPrefix = prefix + '_' + idx++;
+    }
+
+    ns = this.logNamespace({ prefix: newPrefix, uri: uri }, wellknownUri === uri);
   }
 
   if (!namespaces.used[ns.uri]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,9 +1527,9 @@
       "dev": true
     },
     "saxen": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-4.0.1.tgz",
-      "integrity": "sha512-lfLJmP2wqbX2U5yBhMmeb/7h12Sm+ap2bt86Wwxwxux2SKh/jXo5MMzzEJRQNE4G8sCTimUmoqLluXLTqcP+zg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-5.0.0.tgz",
+      "integrity": "sha512-cDmy5Ich+LRB9WudoEo16Wr5fkfw+7Sp2csB2oU7dO9O4nhn5igdamOyFFjmNmEH+L7BhA75B/Z1Y7aWR8tq2g=="
     },
     "semver": {
       "version": "2.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,9 +110,9 @@
       "dev": true
     },
     "assertion-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
-      "integrity": "sha1-x/hUOP3UZrx8oWq5DIFRN5el0js=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
       "dev": true
     },
     "babel-code-frame": {
@@ -170,13 +170,17 @@
       "dev": true
     },
     "chai": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-1.10.0.tgz",
-      "integrity": "sha1-5AMcyHZURhp1lD5aNatG6vOcHrk=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.0",
-        "deep-eql": "0.1.3"
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
       }
     },
     "chalk": {
@@ -191,6 +195,12 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -320,12 +330,12 @@
       }
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
+        "type-detect": "4.0.3"
       }
     },
     "deep-is": {
@@ -716,6 +726,12 @@
       "requires": {
         "is-property": "1.0.2"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -1318,6 +1334,12 @@
         "pify": "2.3.0"
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -1504,10 +1526,10 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
-    "sax": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
-      "integrity": "sha1-VjsZx8HeiS4Jv8Ty/DDjwn8JUrk="
+    "saxen": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-4.0.1.tgz",
+      "integrity": "sha512-lfLJmP2wqbX2U5yBhMmeb/7h12Sm+ap2bt86Wwxwxux2SKh/jXo5MMzzEJRQNE4G8sCTimUmoqLluXLTqcP+zg=="
     },
     "semver": {
       "version": "2.0.11",
@@ -1748,9 +1770,9 @@
       }
     },
     "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
     "typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,9 +1527,9 @@
       "dev": true
     },
     "saxen": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/saxen/-/saxen-5.0.0.tgz",
-      "integrity": "sha512-cDmy5Ich+LRB9WudoEo16Wr5fkfw+7Sp2csB2oU7dO9O4nhn5igdamOyFFjmNmEH+L7BhA75B/Z1Y7aWR8tq2g=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-5.0.1.tgz",
+      "integrity": "sha512-IL1iMJi2KRV8yxNZcOK1AJDHq9zoDNf3NtPOnYtl/b7qJii2rpN5Af9oYs8oL/GqMMv5L1ZpVSzQVoveQ8NRSQ=="
     },
     "semver": {
       "version": "2.0.11",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash": "^3.0.0",
     "moddle": "^1.0.0",
-    "saxen": "^4.0.1",
+    "saxen": "^5.0.0",
     "tiny-stack": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash": "^3.0.0",
     "moddle": "^1.0.0",
-    "saxen": "^5.0.0",
+    "saxen": "^5.0.1",
     "tiny-stack": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^4.1.2",
     "eslint": "^3.19.0",
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^4.0.1",
@@ -45,7 +45,7 @@
   "dependencies": {
     "lodash": "^3.0.0",
     "moddle": "^1.0.0",
-    "sax": "~0.6.0",
+    "saxen": "^4.0.1",
     "tiny-stack": "^0.1.0"
   }
 }

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -903,6 +903,54 @@ describe('Reader', function() {
     });
 
 
+    it('should handle invalid attribute', function(done) {
+
+      var xml = '<props:complexAttrs xmlns:props="http://properties" foo />';
+
+      var reader = new Reader(model);
+      var rootHandler = reader.handler('props:ComplexAttrs');
+
+      // when
+      reader.fromXML(xml, rootHandler, function(err, result, context) {
+
+        expect(err).not.to.exist;
+        expect(context.warnings).to.have.length(1);
+
+        // then
+        expect(result).to.jsonEqual({
+          $type: 'props:ComplexAttrs'
+        });
+
+        done();
+      });
+
+    });
+
+
+    it('should handle unparsable attributes', function(done) {
+
+      var xml = '<props:complexAttrs foo=\'"" />';
+
+      var reader = new Reader(model);
+      var rootHandler = reader.handler('props:ComplexAttrs');
+
+      // when
+      reader.fromXML(xml, rootHandler, function(err, result, context) {
+
+        expect(err).not.to.exist;
+        expect(context.warnings).to.have.length(1);
+
+        // then
+        expect(result).to.jsonEqual({
+          $type: 'props:ComplexAttrs'
+        });
+
+        done();
+      });
+
+    });
+
+
     it('should handle non-xml binary file', function(done) {
 
       var data = readFile('test/fixtures/error/binary.png');

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -356,7 +356,6 @@ describe('Reader', function() {
       });
 
 
-      // workaround for #23
       it('generic, non-ns elements', function(done) {
 
         var extensionModel = createModel([ 'extension/base' ]);

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -565,14 +565,35 @@ describe('Reader', function() {
       });
 
 
-      it('parse body CDATA property', function(done) {
+      it('parse body text property / trimmed whitespace', function(done) {
+
+        // given
+        var reader = new Reader(model);
+        var rootHandler = reader.handler('props:SimpleBody');
+
+        var xml = '<props:simpleBody xmlns:props="http://properties">    </props:simpleBody>';
+
+        // when
+        reader.fromXML(xml, rootHandler, function(err, result) {
+
+          // then
+          expect(result).to.jsonEqual({
+            $type: 'props:SimpleBody'
+          });
+
+          done(err);
+        });
+      });
+
+
+      it('parse body CDATA property / trimmed whitespace', function(done) {
 
         // given
         var reader = new Reader(model);
         var rootHandler = reader.handler('props:SimpleBody');
 
         var xml = '<props:simpleBody xmlns:props="http://properties">' +
-                    '<![CDATA[<h2>HTML markup</h2>]]>' +
+                  '   <![CDATA[<h2>HTML markup</h2>]]>' +
                   '</props:simpleBody>';
 
         // when

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -915,7 +915,7 @@ describe('Reader', function() {
       var expectedError =
         'unparsable content <props:references> detected\n\t' +
             'line: 0\n\t' +
-            'column: 88\n\t' +
+            'column: 70\n\t' +
             'nested error: unknown type <props:References>';
 
       // when
@@ -944,7 +944,7 @@ describe('Reader', function() {
       var expectedError =
         'unparsable content <props:invalid> detected\n\t' +
             'line: 0\n\t' +
-            'column: 125\n\t' +
+            'column: 110\n\t' +
             'nested error: unknown type <props:Invalid>';
 
       // when
@@ -972,7 +972,7 @@ describe('Reader', function() {
       var expectedError =
         'unparsable content <other:foo> detected\n\t' +
             'line: 0\n\t' +
-            'column: 99\n\t' +
+            'column: 88\n\t' +
             'nested error: unrecognized element <other:foo>';
 
       // when
@@ -987,7 +987,6 @@ describe('Reader', function() {
       });
     });
 
-
     it('should handle duplicate id', function(done) {
 
       var xml = '<props:root xmlns:props="http://properties" id="root">' +
@@ -1000,7 +999,7 @@ describe('Reader', function() {
       var expectedError =
         'unparsable content <props:baseWithId> detected\n\t' +
             'line: 0\n\t' +
-            'column: 84\n\t' +
+            'column: 54\n\t' +
             'nested error: duplicate ID <root>';
 
       // when
@@ -1162,7 +1161,7 @@ describe('Reader', function() {
         expect(warning.message).to.eql(
           'unparsable content <props:unknownElement> detected\n\t' +
             'line: 0\n\t' +
-            'column: 84\n\t' +
+            'column: 52\n\t' +
             'nested error: unknown type <props:UnknownElement>');
 
         // then
@@ -1199,7 +1198,7 @@ describe('Reader', function() {
         expect(warning.message).to.eql(
           'unparsable content <unknownElement> detected\n\t' +
             'line: 0\n\t' +
-            'column: 80\n\t' +
+            'column: 52\n\t' +
             'nested error: unrecognized element <unknownElement>');
 
         // then

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1037,6 +1037,86 @@ describe('Writer', function() {
       });
 
 
+      describe('should deconflict namespace prefixes', function() {
+
+        it('on nested Any', function() {
+
+          // given
+          var writer = createWriter(extensionModel);
+
+          var root = extensionModel.create('e:Root', {
+            extensions: [
+              extensionModel.createAny('e:foo', 'http://not-extensions', {
+                foo: 'BAR'
+              })
+            ]
+          });
+
+          // when
+          var xml = writer.toXML(root);
+
+          var expectedXml =
+            '<e:root xmlns:e="http://extensions" ' +
+                      'xmlns:e_1="http://not-extensions">' +
+              '<e_1:foo foo="BAR" />' +
+            '</e:root>';
+
+          // then
+          expect(xml).to.eql(expectedXml);
+        });
+
+
+        it('on explicitly added namespace', function() {
+
+          // given
+          var writer = createWriter(extensionModel);
+
+          var root = extensionModel.create('e:Root', {
+            'xmlns:e': 'http://not-extensions'
+          });
+
+          // when
+          var xml = writer.toXML(root);
+
+          var expectedXml =
+            '<e_1:root xmlns:e_1="http://extensions" ' +
+                      'xmlns:e="http://not-extensions" />';
+
+          // then
+          expect(xml).to.eql(expectedXml);
+        });
+
+
+        it('on explicitly added namespace + Any', function() {
+
+          // given
+          var writer = createWriter(extensionModel);
+
+          var root = extensionModel.create('e:Root', {
+            'xmlns:e': 'http://not-extensions',
+            extensions: [
+              extensionModel.createAny('e:foo', 'http://not-extensions', {
+                foo: 'BAR'
+              })
+            ]
+          });
+
+          // when
+          var xml = writer.toXML(root);
+
+          var expectedXml =
+            '<e_1:root xmlns:e_1="http://extensions" ' +
+                      'xmlns:e="http://not-extensions">' +
+              '<e:foo foo="BAR" />' +
+            '</e_1:root>';
+
+          // then
+          expect(xml).to.eql(expectedXml);
+        });
+
+      });
+
+
       it('should write manually added custom namespace', function() {
 
         // given

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1112,13 +1112,13 @@ describe('Writer', function() {
       });
 
 
-      // workaround for #23
-      it('should write non-ns element', function() {
+      // #23
+      it('should write unqualified element', function() {
 
         // given
         var writer = createWriter(extensionModel);
 
-        // explicitly create element without prefix / namespace
+        // explicitly create element with elementForm=unqualified
         var root = extensionModel.createAny('root', undefined, {
           key: 'FOO',
           value: 'BAR'


### PR DESCRIPTION
Saxen `4.0.0` should be ready for production usage, so... 😉.

Closes #25, with all the benefits.

Adresses the following issues, too:

* #23
* #27