### PR TITLE
Handle nested namespaces during import/export

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -19,6 +19,63 @@ var XML_PREAMBLE = '<?xml version="1.0" encoding="UTF-8"?>\n',
     XSI_TYPE = common.XSI_TYPE;
 
 
+function Namespaces(parent) {
+
+  var prefixMap = {};
+  var uriMap = {};
+  var used = {};
+
+  var wellknown = [];
+  var custom = [];
+
+  // API
+
+  this.byUri = function(uri) {
+    return uriMap[uri] || (
+      parent && parent.byUri(uri)
+    );
+  };
+
+  this.add = function(ns, isWellknown) {
+
+    uriMap[ns.uri] = ns;
+
+    if (isWellknown) {
+      wellknown.push(ns);
+    } else {
+      custom.push(ns);
+    }
+
+    this.mapPrefix(ns.prefix, ns.uri);
+  };
+
+  this.uriByPrefix = function(prefix) {
+    return prefixMap[prefix || 'xmlns'];
+  };
+
+  this.mapPrefix = function(prefix, uri) {
+    prefixMap[prefix || 'xmlns'] = uri;
+  };
+
+  this.logUsed = function(ns) {
+    var uri = ns.uri;
+
+    used[uri] = this.byUri(uri);
+  };
+
+  this.getUsed = function(ns) {
+
+    function isUsed(ns) {
+      return used[ns.uri];
+    }
+
+    var allNs = [].concat(wellknown, custom);
+
+    return allNs.filter(isUsed);
+  };
+
+}
+
 function lower(string) {
   return string.charAt(0).toLowerCase() + string.slice(1);
 }
@@ -53,18 +110,11 @@ function nsName(ns) {
 
 function getNsAttrs(namespaces) {
 
-  function isUsed(ns) {
-    return namespaces.used[ns.uri];
-  }
-
-  function toAttr(ns) {
+  return map(namespaces.getUsed(), function(ns) {
     var name = 'xmlns' + (ns.prefix ? ':' + ns.prefix : '');
     return { name: name, value: ns.uri };
-  }
+  });
 
-  var allNs = [].concat(namespaces.wellknown, namespaces.custom);
-
-  return map(filter(allNs, isUsed), toAttr);
 }
 
 function getElementNs(ns, descriptor) {
@@ -145,8 +195,8 @@ function filterContained(props) {
 }
 
 
-function ReferenceSerializer(parent, ns) {
-  this.ns = ns;
+function ReferenceSerializer(tagName) {
+  this.tagName = tagName;
 }
 
 ReferenceSerializer.prototype.build = function(element) {
@@ -157,7 +207,7 @@ ReferenceSerializer.prototype.build = function(element) {
 ReferenceSerializer.prototype.serializeTo = function(writer) {
   writer
     .appendIndent()
-    .append('<' + nsName(this.ns) + '>' + this.element.id + '</' + nsName(this.ns) + '>')
+    .append('<' + this.tagName + '>' + this.element.id + '</' + this.tagName + '>')
     .appendNewLine();
 };
 
@@ -187,8 +237,8 @@ BodySerializer.prototype.build = function(prop, value) {
   return this;
 };
 
-function ValueSerializer(ns) {
-  this.ns = ns;
+function ValueSerializer(tagName) {
+  this.tagName = tagName;
 }
 
 inherits(ValueSerializer, BodySerializer);
@@ -197,42 +247,57 @@ ValueSerializer.prototype.serializeTo = function(writer) {
 
   writer
     .appendIndent()
-    .append('<' + nsName(this.ns) + '>');
+    .append('<' + this.tagName + '>');
 
   this.serializeValue(writer);
 
   writer
-    .append('</' + nsName(this.ns) + '>')
+    .append('</' + this.tagName + '>')
     .appendNewLine();
 };
 
-function ElementSerializer(parent, ns) {
+function ElementSerializer(parent, propertyDescriptor) {
   this.body = [];
   this.attrs = [];
 
   this.parent = parent;
-  this.ns = ns;
+  this.propertyDescriptor = propertyDescriptor;
 }
 
 ElementSerializer.prototype.build = function(element) {
   this.element = element;
 
-  var otherAttrs = this.parseNsAttributes(element);
+  var elementDescriptor = element.$descriptor,
+      propertyDescriptor = this.propertyDescriptor;
 
-  if (!this.ns) {
-    this.ns = this.nsTagName(element.$descriptor);
+  var otherAttrs,
+      properties;
+
+  var isGeneric = elementDescriptor.isGeneric;
+
+  if (isGeneric) {
+    otherAttrs = this.parseGeneric(element);
+  } else {
+    otherAttrs = this.parseNsAttributes(element);
   }
 
-  if (element.$descriptor.isGeneric) {
-    this.parseGeneric(element);
+  if (propertyDescriptor) {
+    this.ns = this.nsPropertyTagName(propertyDescriptor);
   } else {
-    var properties = getSerializableProperties(element);
+    this.ns = this.nsTagName(elementDescriptor);
+  }
+
+  // compute tag name
+  this.tagName = this.addTagName(this.ns);
+
+  if (!isGeneric) {
+    properties = getSerializableProperties(element);
 
     this.parseAttributes(filterAttributes(properties));
     this.parseContainments(filterContained(properties));
-
-    this.parseGenericAttributes(element, otherAttrs);
   }
+
+  this.parseGenericAttributes(element, otherAttrs);
 
   return this;
 };
@@ -255,7 +320,7 @@ ElementSerializer.prototype.isLocalNs = function(ns) {
  * Get the actual ns attribute name for the given element.
  *
  * @param {Object} element
- * @param {Boolean} [inherited=false]
+ * @param {Boolean} [element.inherited=false]
  *
  * @return {Object} nsName
  */
@@ -277,6 +342,9 @@ ElementSerializer.prototype.nsAttributeName = function(element) {
   // parse + log effective ns
   var effectiveNs = this.logNamespaceUsed(ns);
 
+  // LOG ACTUAL namespace use
+  this.getNamespaces().logUsed(effectiveNs);
+
   // strip prefix if same namespace like parent
   if (this.isLocalNs(effectiveNs)) {
     return { localName: ns.localName };
@@ -288,10 +356,13 @@ ElementSerializer.prototype.nsAttributeName = function(element) {
 ElementSerializer.prototype.parseGeneric = function(element) {
 
   var self = this,
-      body = this.body,
-      attrs = this.attrs;
+      body = this.body;
+
+  var attributes = [];
 
   forEach(element, function(val, key) {
+
+    var nonNsAttr;
 
     if (key === '$body') {
       body.push(new BodySerializer().build({ type: 'String' }, val));
@@ -302,10 +373,52 @@ ElementSerializer.prototype.parseGeneric = function(element) {
       });
     } else
     if (key.indexOf('$') !== 0) {
-      attrs.push({ name: key, value: escapeAttr(val) });
+      nonNsAttr = self.parseNsAttribute(element, key, val);
+
+      if (nonNsAttr) {
+        attributes.push({ name: key, value: val });
+      }
     }
   });
+
+  return attributes;
 };
+
+ElementSerializer.prototype.parseNsAttribute = function(element, name, value) {
+  var model = element.$model;
+
+  var nameNs = parseNameNs(name);
+
+  var ns;
+
+  // parse xmlns:foo="http://foo.bar"
+  if (nameNs.prefix === 'xmlns') {
+    ns = { prefix: nameNs.localName, uri: value };
+  }
+
+  // parse xmlns="http://foo.bar"
+  if (!nameNs.prefix && nameNs.localName === 'xmlns') {
+    ns = { uri: value };
+  }
+
+  if (!ns) {
+    return {
+      name: name,
+      value: value
+    };
+  }
+
+  if (model && model.getPackage(value)) {
+    // register well known namespace
+    this.logNamespace(ns, true, true);
+  } else {
+    // log custom namespace directly as used
+    var actualNs = this.logNamespaceUsed(ns, true);
+
+    this.getNamespaces().logUsed(actualNs);
+  }
+};
+
 
 /**
  * Parse namespaces and return a list of left over generic attributes
@@ -313,12 +426,10 @@ ElementSerializer.prototype.parseGeneric = function(element) {
  * @param  {Object} element
  * @return {Array<Object>}
  */
-ElementSerializer.prototype.parseNsAttributes = function(element) {
+ElementSerializer.prototype.parseNsAttributes = function(element, attrs) {
   var self = this;
 
   var genericAttrs = element.$attrs;
-
-  var model = element.$model;
 
   var attributes = [];
 
@@ -326,30 +437,11 @@ ElementSerializer.prototype.parseNsAttributes = function(element) {
   // and log them. push non namespace attributes to a list
   // and process them later
   forEach(genericAttrs, function(value, name) {
-    var nameNs = parseNameNs(name);
 
-    var ns;
+    var nonNsAttr = self.parseNsAttribute(element, name, value);
 
-    // parse xmlns:foo="http://foo.bar"
-    if (nameNs.prefix === 'xmlns') {
-      ns = { prefix: nameNs.localName, uri: value };
-    }
-
-    // parse xmlns="http://foo.bar"
-    if (!nameNs.prefix && nameNs.localName === 'xmlns') {
-      ns = { uri: value };
-    }
-
-    if (ns) {
-      if (model.getPackage(value)) {
-        // register well known namespace
-        self.logNamespace(ns, true);
-      } else {
-        // log custom namespace directly as used
-        self.logNamespaceUsed(ns);
-      }
-    } else {
-      attributes.push({ name: name, value: value });
+    if (nonNsAttr) {
+      attributes.push(nonNsAttr);
     }
   });
 
@@ -390,8 +482,6 @@ ElementSerializer.prototype.parseContainments = function(properties) {
         isReference = p.isReference,
         isMany = p.isMany;
 
-    var ns = self.nsPropertyTagName(p);
-
     if (!isMany) {
       value = [ value ];
     }
@@ -401,12 +491,12 @@ ElementSerializer.prototype.parseContainments = function(properties) {
     } else
     if (Types.isSimple(p.type)) {
       forEach(value, function(v) {
-        body.push(new ValueSerializer(ns).build(p, v));
+        body.push(new ValueSerializer(self.addTagName(self.nsPropertyTagName(p))).build(p, v));
       });
     } else
     if (isReference) {
       forEach(value, function(v) {
-        body.push(new ReferenceSerializer(self, ns).build(v));
+        body.push(new ReferenceSerializer(self.addTagName(self.nsPropertyTagName(p))).build(v));
       });
     } else {
       // allow serialization via type
@@ -418,10 +508,10 @@ ElementSerializer.prototype.parseContainments = function(properties) {
         var serializer;
 
         if (asType) {
-          serializer = new TypeSerializer(self, ns);
+          serializer = new TypeSerializer(self, p);
         } else
         if (asProperty) {
-          serializer = new ElementSerializer(self, ns);
+          serializer = new ElementSerializer(self, p);
         } else {
           serializer = new ElementSerializer(self);
         }
@@ -432,50 +522,46 @@ ElementSerializer.prototype.parseContainments = function(properties) {
   });
 };
 
-ElementSerializer.prototype.getNamespaces = function() {
+ElementSerializer.prototype.getNamespaces = function(local) {
 
   var namespaces = this.namespaces,
-      parent = this.parent;
+      parent = this.parent,
+      parentNamespaces;
 
   if (!namespaces) {
-    namespaces = this.namespaces = parent ? parent.getNamespaces() : {
-      prefixMap: {},
-      uriMap: {},
-      used: {},
-      wellknown: [],
-      custom: []
-    };
+    parentNamespaces = parent && parent.getNamespaces();
+
+    if (local || !parentNamespaces) {
+      this.namespaces = namespaces = new Namespaces(parentNamespaces);
+    } else {
+      namespaces = parentNamespaces;
+    }
   }
 
   return namespaces;
 };
 
-ElementSerializer.prototype.logNamespace = function(ns, wellknown) {
-  var namespaces = this.getNamespaces();
+ElementSerializer.prototype.logNamespace = function(ns, wellknown, local) {
+  var namespaces = this.getNamespaces(local);
 
-  var nsUri = ns.uri;
+  var nsUri = ns.uri,
+      nsPrefix = ns.prefix;
 
-  var existing = namespaces.uriMap[nsUri];
+  var existing = namespaces.byUri(nsUri);
 
   if (!existing) {
-    namespaces.uriMap[nsUri] = ns;
-
-    if (wellknown) {
-      namespaces.wellknown.push(ns);
-    } else {
-      namespaces.custom.push(ns);
-    }
+    namespaces.add(ns, wellknown);
   }
 
-  namespaces.prefixMap[ns.prefix] = nsUri;
+  namespaces.mapPrefix(nsPrefix, nsUri);
 
   return ns;
 };
 
-ElementSerializer.prototype.logNamespaceUsed = function(ns) {
+ElementSerializer.prototype.logNamespaceUsed = function(ns, local) {
   var element = this.element,
       model = element.$model,
-      namespaces = this.getNamespaces();
+      namespaces = this.getNamespaces(local);
 
   // ns may be
   //
@@ -495,28 +581,24 @@ ElementSerializer.prototype.logNamespaceUsed = function(ns) {
 
   wellknownUri = DEFAULT_NS_MAP[prefix] || model && (model.getPackage(prefix) || {}).uri;
 
-  uri = uri || wellknownUri || namespaces.prefixMap[prefix];
+  uri = uri || wellknownUri || namespaces.uriByPrefix(prefix);
 
   if (!uri) {
     throw new Error('no namespace uri given for prefix <' + prefix + '>');
   }
 
-  ns = namespaces.uriMap[uri];
+  ns = namespaces.byUri(uri);
 
   if (!ns) {
     newPrefix = prefix;
     idx = 1;
 
     // find a prefix that is not mapped yet
-    while (namespaces.prefixMap[newPrefix]) {
+    while (namespaces.uriByPrefix(newPrefix)) {
       newPrefix = prefix + '_' + idx++;
     }
 
     ns = this.logNamespace({ prefix: newPrefix, uri: uri }, wellknownUri === uri);
-  }
-
-  if (!namespaces.used[ns.uri]) {
-    namespaces.used[ns.uri] = ns;
   }
 
   return ns;
@@ -550,6 +632,14 @@ ElementSerializer.prototype.parseAttributes = function(properties) {
   });
 };
 
+ElementSerializer.prototype.addTagName = function(nsTagName) {
+  var actualNs = this.logNamespaceUsed(nsTagName);
+
+  this.getNamespaces().logUsed(actualNs);
+
+  return nsName(nsTagName);
+};
+
 ElementSerializer.prototype.addAttribute = function(name, value) {
   var attrs = this.attrs;
 
@@ -562,10 +652,10 @@ ElementSerializer.prototype.addAttribute = function(name, value) {
 
 ElementSerializer.prototype.serializeAttributes = function(writer) {
   var attrs = this.attrs,
-      root = !this.parent;
+      namespaces = this.namespaces;
 
-  if (root) {
-    attrs = getNsAttrs(this.namespaces).concat(attrs);
+  if (namespaces) {
+    attrs = getNsAttrs(namespaces).concat(attrs);
   }
 
   forEach(attrs, function(a) {
@@ -581,7 +671,7 @@ ElementSerializer.prototype.serializeTo = function(writer) {
 
   writer
     .appendIndent()
-    .append('<' + nsName(this.ns));
+    .append('<' + this.tagName);
 
   this.serializeAttributes(writer);
 
@@ -605,7 +695,7 @@ ElementSerializer.prototype.serializeTo = function(writer) {
         .appendIndent();
     }
 
-    writer.append('</' + nsName(this.ns) + '>');
+    writer.append('</' + this.tagName + '>');
   }
 
   writer.appendNewLine();
@@ -614,32 +704,34 @@ ElementSerializer.prototype.serializeTo = function(writer) {
 /**
  * A serializer for types that handles serialization of data types
  */
-function TypeSerializer(parent, ns) {
-  ElementSerializer.call(this, parent, ns);
+function TypeSerializer(parent, propertyDescriptor) {
+  ElementSerializer.call(this, parent, propertyDescriptor);
 }
 
 inherits(TypeSerializer, ElementSerializer);
 
-TypeSerializer.prototype.build = function(element) {
+TypeSerializer.prototype.parseNsAttributes = function(element) {
+
+  // extracted attributes
+  var attributes = ElementSerializer.prototype.parseNsAttributes.call(this, element);
+
   var descriptor = element.$descriptor;
 
-  this.element = element;
-
-  this.typeNs = this.nsTagName(descriptor);
+  var typeNs = this.typeNs = this.nsTagName(descriptor);
+  this.getNamespaces().logUsed(this.typeNs);
 
   // add xsi:type attribute to represent the elements
   // actual type
 
-  var typeNs = this.typeNs,
-      pkg = element.$model.getPackage(typeNs.uri),
+  var pkg = element.$model.getPackage(typeNs.uri),
       typePrefix = (pkg.xml && pkg.xml.typePrefix) || '';
 
-  this.addAttribute(this.nsAttributeName(XSI_TYPE),
-    (typeNs.prefix ? typeNs.prefix + ':' : '') +
-    typePrefix + descriptor.ns.localName);
+  this.addAttribute(
+    this.nsAttributeName(XSI_TYPE),
+    (typeNs.prefix ? typeNs.prefix + ':' : '') + typePrefix + descriptor.ns.localName
+  );
 
-  // do the usual stuff
-  return ElementSerializer.prototype.build.call(this, element);
+  return attributes;
 };
 
 TypeSerializer.prototype.isLocalNs = function(ns) {

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -717,6 +717,11 @@ TypeSerializer.prototype.parseNsAttributes = function(element) {
 
   var descriptor = element.$descriptor;
 
+  // only serialize xsi:type if necessary
+  if (descriptor.name === this.propertyDescriptor.type) {
+    return attributes;
+  }
+
   var typeNs = this.typeNs = this.nsTagName(descriptor);
   this.getNamespaces().logUsed(this.typeNs);
 

--- a/test/fixtures/model/datatype-aliased.json
+++ b/test/fixtures/model/datatype-aliased.json
@@ -7,6 +7,10 @@
   },
   "types": [
     {
+      "name": "Root",
+      "superClass": [ "dt:Root" ]
+    },
+    {
       "name": "Rect",
       "properties": [
         { "name": "z", "type": "Integer", "isAttr": true }

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -41,8 +41,11 @@
       ]
     },
     {
+      "name": "Body"
+    },
+    {
       "name": "SimpleBody",
-      "superClass": [ "Base" ],
+      "superClass": [ "Base", "Body" ],
       "properties": [
         {
           "name": "body",
@@ -57,7 +60,7 @@
       "properties": [
         {
           "name": "someBody",
-          "type": "SimpleBody",
+          "type": "Body",
           "xml": { "serialize" : "xsi:type" }
         }
       ]

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -1723,6 +1723,119 @@ describe('Reader', function() {
 
       });
 
+
+      describe('namespace declarations', function() {
+
+        it('should handle nested', function(done) {
+
+          // given
+          var reader = new Reader(extensionModel);
+          var rootHandler = reader.handler('e:Root');
+
+          var xml =
+            '<e:root xmlns:e="http://extensions">' +
+              '<bar:bar xmlns:bar="http://bar">' +
+                '<other:child b="B" xmlns:other="http://other" />' +
+              '</bar:bar>' +
+              '<foo xmlns="http://foo">' +
+                '<child a="A" />' +
+              '</foo>' +
+            '</e:root>';
+
+          // when
+          reader.fromXML(xml, rootHandler, function(err, result) {
+
+            if (err) {
+              return done(err);
+            }
+
+            // then
+            expect(result).to.jsonEqual({
+              $type: 'e:Root',
+              extensions: [
+                {
+                  $type: 'bar:bar',
+                  'xmlns:bar': 'http://bar',
+                  $children: [
+                    {
+                      $type: 'other:child',
+                      'xmlns:other': 'http://other',
+                      b: 'B'
+                    }
+                  ]
+                },
+                {
+                  $type: 'ns0:foo',
+                  'xmlns': 'http://foo',
+                  $children: [
+                    { $type: 'ns0:child', a: 'A' }
+                  ]
+                }
+              ]
+            });
+
+            done();
+          });
+        });
+
+
+        it('should handle nested, re-declaring default', function(done) {
+
+          // given
+          var reader = new Reader(extensionModel);
+          var rootHandler = reader.handler('e:Root');
+
+          var xml =
+            '<root xmlns="http://extensions">' +
+              '<bar:bar xmlns:bar="http://bar">' +
+                '<other:child b="B" xmlns:other="http://other" />' +
+              '</bar:bar>' +
+              '<foo xmlns="http://foo">' +
+                '<child a="A" />' +
+              '</foo>' +
+            '</root>';
+
+          // when
+          reader.fromXML(xml, rootHandler, function(err, result) {
+
+            if (err) {
+              return done(err);
+            }
+
+            // then
+            expect(result).to.jsonEqual({
+              $type: 'e:Root',
+              extensions: [
+                {
+                  $type: 'bar:bar',
+                  'xmlns:bar': 'http://bar',
+                  $children: [
+                    {
+                      $type: 'other:child',
+                      'xmlns:other': 'http://other',
+                      b: 'B'
+                    }
+                  ]
+                },
+                {
+                  $type: 'ns0:foo',
+                  'xmlns': 'http://foo',
+                  $children: [
+                    {
+                      $type: 'ns0:child',
+                      a: 'A'
+                    }
+                  ]
+                }
+              ]
+            });
+
+            done();
+          });
+        });
+
+      });
+
     });
 
   });

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -55,8 +55,8 @@ describe('Writer', function() {
 
         // then
         expect(xml).to.eql(
-          '<dt:root xmlns:dt="http://datatypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<dt:bounds xsi:type="dt:Rect" y="100" />' +
+          '<dt:root xmlns:dt="http://datatypes">' +
+            '<dt:bounds y="100" />' +
           '</dt:root>');
       });
 
@@ -75,8 +75,8 @@ describe('Writer', function() {
 
         // then
         expect(xml).to.eql(
-          '<root xmlns="http://datatypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<bounds xsi:type="Rect" y="100" />' +
+          '<root xmlns="http://datatypes">' +
+            '<bounds y="100" />' +
           '</root>');
       });
 
@@ -95,8 +95,8 @@ describe('Writer', function() {
 
         // then
         expect(xml).to.eql(
-          '<a:root xmlns:a="http://datatypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-            '<a:bounds xsi:type="a:Rect" y="100" />' +
+          '<a:root xmlns:a="http://datatypes">' +
+            '<a:bounds y="100" />' +
           '</a:root>');
       });
 
@@ -119,9 +119,9 @@ describe('Writer', function() {
         // then
         expect(xml).to.eql(
           '<dt:root xmlns:dt="http://datatypes" ' +
-                   'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
-                   'xmlns:do="http://datatypes2">' +
-            '<dt:otherBounds xsi:type="dt:Rect" y="200" />' +
+                   'xmlns:do="http://datatypes2" ' +
+                   'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+            '<dt:otherBounds y="200" />' +
             '<dt:otherBounds xsi:type="do:Rect" x="100" />' +
           '</dt:root>');
       });
@@ -148,7 +148,7 @@ describe('Writer', function() {
                    'xmlns:da="http://datatypes-aliased" ' +
                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
             '<dt:otherBounds xsi:type="da:tRect" z="200" />' +
-            '<dt:otherBounds xsi:type="dt:Rect" y="100" />' +
+            '<dt:otherBounds y="100" />' +
           '</dt:root>');
       });
 
@@ -1512,7 +1512,6 @@ describe('Writer', function() {
 
       var root = model.create('da:Root', {
         'xmlns:a' : 'http://datatypes-aliased',
-        'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
         otherBounds: [
           model.create('dt:Rect', {
             'xmlns': 'http://datatypes',
@@ -1526,9 +1525,8 @@ describe('Writer', function() {
 
       // then
       expect(xml).to.eql(
-        '<a:Root xmlns:a="http://datatypes-aliased" ' +
-                'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-          '<otherBounds xmlns="http://datatypes" xsi:type="Rect" y="100" />' +
+        '<a:Root xmlns:a="http://datatypes-aliased">' +
+          '<otherBounds xmlns="http://datatypes" y="100" />' +
         '</a:Root>');
 
     });


### PR DESCRIPTION
Incorporated improvements:

* handle nested namespaces during import and export (closes #19)
* only write `xsi:type` attribute if needed