### PR TITLE
feat(read): emit warning on unknown well-known NS attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [moddle-xml](https://github.com/bpmn-io/moddle-xml) are d
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: warn on invalid attributes under well-known namespaces ([#32](https://github.com/bpmn-io/moddle-xml/issues/32))
+
 ## 7.1.0
 
 * `CHORE`: bump dependency versions

--- a/lib/read.js
+++ b/lib/read.js
@@ -299,7 +299,9 @@ ElementHandler.prototype.createElement = function(node) {
       Type = this.type,
       descriptor = getModdleDescriptor(Type),
       context = this.context,
-      instance = new Type({});
+      instance = new Type({}),
+      model = this.model,
+      propNameNs;
 
   forEach(attributes, function(value, name) {
 
@@ -330,6 +332,20 @@ ElementHandler.prototype.createElement = function(node) {
     } else {
       if (prop) {
         value = coerceType(prop.type, value);
+      } else {
+        propNameNs = parseNameNs(name, descriptor.ns.prefix);
+
+        // check whether attribute is defined in a well-known namespace
+        // if that is the case we emit a warning to indicate potential misuse
+        if (model.getPackage(propNameNs.prefix)) {
+
+          context.addWarning({
+            message: 'unknown attribute <' + name + '>',
+            element: instance,
+            property: name,
+            value: value
+          });
+        }
       }
 
       instance.set(name, value);
@@ -370,7 +386,9 @@ ElementHandler.prototype.getPropertyForNode = function(node) {
 
         elementType = model.getType(elementTypeName);
 
-        return assign({}, property, { effectiveType: getModdleDescriptor(elementType).name });
+        return assign({}, property, {
+          effectiveType: getModdleDescriptor(elementType).name
+        });
       }
     }
 
@@ -390,7 +408,9 @@ ElementHandler.prototype.getPropertyForNode = function(node) {
     });
 
     if (property) {
-      return assign({}, property, { effectiveType: getModdleDescriptor(elementType).name });
+      return assign({}, property, {
+        effectiveType: getModdleDescriptor(elementType).name
+      });
     }
   } else {
     // parse unknown element (maybe extension)


### PR DESCRIPTION
Once merged into our upstream libraries this helps people run into problems such as [this one](https://forum.bpmn.io/t/storing-meta-data-for-camunda-inputparameters/2226/7).

Closes #32