### PR TITLE
chore(read): replace tiny-stack with extended Array with peek functionality

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -4,8 +4,6 @@ import {
   assign
 } from 'min-dash';
 
-import Stack from 'tiny-stack';
-
 import {
   Parser as SaxParser
 } from 'saxen';
@@ -25,7 +23,6 @@ import {
   serializeAsType,
   hasLowerCaseAlias
 } from './common';
-
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
@@ -639,7 +636,7 @@ Reader.prototype.fromXML = function(xml, options, done) {
 
   var context = new Context(assign({}, options, { rootHandler: rootHandler })),
       parser = new SaxParser({ proxy: true }),
-      stack = new Stack();
+      stack = createStack();
 
   rootHandler.context = context;
 
@@ -874,3 +871,11 @@ Reader.prototype.fromXML = function(xml, options, done) {
 Reader.prototype.handler = function(name) {
   return new RootElementHandler(this.model, name);
 };
+
+function createStack() {
+  var stack = [];
+  stack.peek = function peek() {
+    return stack[stack.length - 1];
+  };
+  return stack;
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "min-dash": "^3.0.0",
     "moddle": "^4.1.0",
-    "saxen": "^8.1.0",
-    "tiny-stack": "^1.0.0"
+    "saxen": "^8.1.0"
   }
 }


### PR DESCRIPTION
Imho, given the usage of the tiny-stack lib the dependency can be removed and replaced with a self maintained class.