### PR TITLE
fix(read): prevent attr <> child conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ All notable changes to [moddle-xml](https://github.com/bpmn-io/moddle-xml) are d
 
 ___Note:__ Yet to be released changes appear here._
 
+## 8.0.2
+
+* `FIX`: read element as type if conflicting named propery is defines an attribute ([#43](https://github.com/bpmn-io/moddle-xml/issues/43))
+
 ## 8.0.1
 
 * `DOCS`: update documentation
+
 ## 8.0.0
 
 * `FEAT`: provide pre-packaged distribution

--- a/lib/read.js
+++ b/lib/read.js
@@ -383,7 +383,7 @@ ElementHandler.prototype.getPropertyForNode = function(node) {
 
   // search for properties by name first
 
-  if (property) {
+  if (property && !property.isAttr) {
 
     if (serializeAsType(property)) {
       elementTypeName = node.attributes[XSI_TYPE];

--- a/test/fixtures/model/attr-child-conflict.json
+++ b/test/fixtures/model/attr-child-conflict.json
@@ -1,0 +1,23 @@
+{
+  "name": "S",
+  "uri": "http://s",
+  "prefix": "s",
+  "xml": {
+    "tagAlias": "lowerCase"
+  },
+  "types": [
+    {
+      "name": "Foo",
+      "properties": [
+        { "name": "bar", "type": "String", "isAttr": true },
+        { "name": "bars", "type": "Bar", "isMany": true }
+      ]
+    },
+    {
+      "name": "Bar",
+      "properties": [
+        { "name": "woop", "type": "String", "isAttr": true }
+      ]
+    }
+  ]
+}

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -2534,4 +2534,48 @@ describe('Reader', function() {
 
   });
 
+
+  describe('attr <> child conflict', function() {
+
+    var model = createModel([ 'attr-child-conflict' ]);
+
+
+    it('should import attr and child with the same name', function(done) {
+
+      // given
+      var reader = new Reader(model);
+      var rootHandler = reader.handler('s:Foo');
+
+      var xml = `
+        <s:foo xmlns:s="http://s" bar="Bar">
+          <s:bar woop="WHOOPS">
+          </s:bar>
+        </s:foo>`;
+
+      // when
+      reader.fromXML(xml, rootHandler, function(err, result, context) {
+
+        if (err) {
+          return done(err);
+        }
+
+        // then
+        expect(result).to.jsonEqual({
+          $type: 's:Foo',
+          bar: 'Bar',
+          bars: [
+            {
+              $type: 's:Bar',
+              woop: 'WHOOPS'
+            }
+          ]
+        });
+
+        done();
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
Correctly read elements with types matching a known attribute.

This check works, as references defined as child nodes will cause
conflicts => we do not know how to parse this:

```xml
<s:foo>
  <s:bar>REF_TO_BAR</s:bar>
  <s:bar id="REF_TO_BAR" />
</s:foo>
```

Closes #43