### PR TITLE
Backports namespace serialization fix to 8.x

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -564,7 +564,7 @@ ElementSerializer.prototype.logNamespace = function(ns, wellknown, local) {
 
   var existing = namespaces.byUri(nsUri);
 
-  if (!existing) {
+  if (!existing || local) {
     namespaces.add(ns, wellknown);
   }
 

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -930,6 +930,32 @@ describe('Writer', function() {
         expect(xml).to.eql('<foo:root xmlns:foo="http://properties" id="Root" />');
       });
 
+
+      it('local namespace re-definition', function() {
+
+        // given
+        var writer = createWriter(extendedModel);
+
+        var root = extendedModel.create('props:Root', {
+          xmlns: 'http://properties',
+          id: 'Root',
+          'xmlns:ext': 'http://extended',
+          any: [
+            extendedModel.create('ext:ExtendedComplex', { xmlns: 'http://extended' })
+          ]
+        });
+
+        // when
+        var xml = writer.toXML(root);
+
+        // then
+        expect(xml).to.eql(
+          '<root xmlns="http://properties" id="Root">' +
+            '<extendedComplex xmlns="http://extended" />' +
+          '</root>'
+        );
+      });
+
     });
 
 


### PR DESCRIPTION
Backports https://github.com/bpmn-io/moddle-xml/pull/47 to `8.x` branch.