### PR TITLE
Reuse global namespace

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -63,17 +63,32 @@ export function Namespaces(parent) {
     prefixMap[prefix || 'xmlns'] = uri;
   };
 
-  this.logUsed = function(ns) {
-    var uri = ns.uri;
+  this.getNSKey = function(ns) {
+    return (ns.prefix !== undefined) ? (ns.uri + '|' + ns.prefix) : ns.uri;
+  };
 
-    used[uri] = this.byUri(uri);
+  this.logUsed = function(ns) {
+
+    var uri = ns.uri;
+    var nsKey = this.getNSKey(ns);
+
+    used[nsKey] = this.byUri(uri);
+
+    // Inform parent recursively about the usage of this NS
+    if (parent) {
+      parent.logUsed(ns);
+    }
   };
 
   this.getUsed = function(ns) {
 
     function isUsed(ns) {
-      return used[ns.uri];
+      var nsKey = self.getNSKey(ns);
+
+      return used[nsKey];
     }
+
+    var self = this;
 
     var allNs = [].concat(wellknown, custom);
 

--- a/test/spec/rountrip.js
+++ b/test/spec/rountrip.js
@@ -1,0 +1,90 @@
+import expect from '../expect';
+
+import {
+  assign
+} from 'min-dash';
+
+import {
+  Reader,
+  Writer
+} from '../../lib';
+
+import {
+  createModelBuilder
+} from '../helper';
+
+
+describe('Roundtrip', function() {
+
+  var createModel = createModelBuilder('test/fixtures/model/');
+
+  var createWriter = function(model, options) {
+    return new Writer(assign({ preamble: false }, options || {}));
+  };
+
+
+  it('should strip unused global', async function() {
+
+    // given
+    var extendedModel = createModel([ 'properties', 'properties-extended' ]);
+
+    var reader = new Reader(extendedModel);
+    var writer = createWriter(extendedModel);
+
+    var rootHandler = reader.handler('ext:Root');
+
+    var input =
+      '<root xmlns="http://extended" xmlns:props="http://properties" id="Root">' +
+        '<props:Base xmlns="http://properties" />' +
+      '</root>';
+
+    // when
+    var {
+      rootElement
+    } = await reader.fromXML(input, rootHandler);
+
+    var output = writer.toXML(rootElement);
+
+    // then
+    expect(output).to.eql(
+      '<root xmlns="http://extended" id="Root">' +
+        '<base xmlns="http://properties" />' +
+      '</root>'
+    );
+  });
+
+
+  it('should reuse global namespace', async function() {
+
+    // given
+    var extendedModel = createModel([ 'properties', 'properties-extended' ]);
+
+    var reader = new Reader(extendedModel);
+    var writer = createWriter(extendedModel);
+
+    var rootHandler = reader.handler('props:ComplexNesting');
+
+    var input =
+      '<root:complexNesting xmlns:root="http://properties" xmlns:ext="http://extended">' +
+        '<complexNesting xmlns="http://properties">' +
+          '<ext:extendedComplex numCount="1" />' +
+        '</complexNesting>' +
+      '</root:complexNesting>';
+
+    // when
+    var {
+      rootElement
+    } = await reader.fromXML(input, rootHandler);
+
+    var output = writer.toXML(rootElement);
+
+    expect(output).to.eql(
+      '<root:complexNesting xmlns:root="http://properties" xmlns:ext="http://extended">' +
+        '<complexNesting xmlns="http://properties">' +
+          '<ext:extendedComplex numCount="1" />' +
+        '</complexNesting>' +
+      '</root:complexNesting>'
+    );
+  });
+
+});

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1780,4 +1780,48 @@ describe('Writer', function() {
 
   });
 
+
+  it('should TEST OUR FIX', function() {
+
+    var model = createModel([
+      'properties',
+      'properties-extended'
+    ]);
+
+    // given
+    var writer = createWriter(model);
+
+    // <props:Root xmlns:props="http://properties" xmlns:ext="http://extended">
+    //   <complexNesting... xmlns="http://props">
+    //     <ext:extendedComplex numCount="1" />
+    //   </complexNesting>
+    // </props:Root>
+    var root = model.create('props:Root', {
+      'xmlns:props': 'http://properties',
+      'xmlns:ext': 'http://extended',
+      any: [
+        model.create('props:ComplexNesting', {
+          'xmlns': 'http://properties',
+          nested: [
+            model.create('ext:ExtendedComplex', { numCount: 1 })
+          ]
+        })
+      ]
+    });
+
+    // when
+    var xml = writer.toXML(root);
+
+    var expectedXML =
+      '<props:root xmlns:props="http://properties" xmlns:ext="http://extended">' +
+        '<complexNesting xmlns="http://properties">' +
+          '<ext:extendedComplex numCount="1" />' +
+        '</complexNesting>' +
+      '</props:root>';
+
+    // then
+    expect(xml).to.eql(expectedXML);
+
+  });
+
 });

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1781,7 +1781,7 @@ describe('Writer', function() {
   });
 
 
-  it('should TEST OUR FIX', function() {
+  it('should reuse global namespace', function() {
 
     var model = createModel([
       'properties',


### PR DESCRIPTION
Related to https://github.com/bpmn-io/bpmn-js/issues/1310

The fix (pretty simple):

When we log a namespace as used, we want to recursively inform the parent namespaces as well.

Also when we log a namespace as used, we want to properly hash the namespaces as we want to differentiate between `{ uri:'http://test' }` and `{ uri:'http://test', prefix:'stuff' }` to keep the 'discarding unused global' behaviour.

This also fixes the broken test in bpmn-moddle: https://github.com/bpmn-io/bpmn-moddle/commit/3948807b9992a0f934fae60e74e04648aa4bd8fd