### PR TITLE
fix(write): correct handling of multiple <xml> namespace declarations

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -1,5 +1,4 @@
 import {
-  map,
   forEach,
   isString,
   filter,
@@ -132,7 +131,11 @@ function nsName(ns) {
 
 function getNsAttrs(namespaces) {
 
-  return map(namespaces.getUsed(), function(ns) {
+  return namespaces.getUsed().filter(function(ns) {
+
+    // do not serialize built in <xml> namespace
+    return ns.prefix !== 'xml';
+  }).map(function(ns) {
     var name = 'xmlns' + (ns.prefix ? ':' + ns.prefix : '');
     return { name: name, value: ns.uri };
   });
@@ -583,7 +586,7 @@ ElementSerializer.prototype.logNamespace = function(ns, wellknown, local) {
 
   var existing = namespaces.byUri(nsUri);
 
-  if (nsPrefix !== 'xml' && (!existing || local)) {
+  if (!existing || local) {
     namespaces.add(ns, wellknown);
   }
 

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -71,6 +71,7 @@ describe('Reader', function() {
 
     var model = createModel([ 'properties' ]);
     var extendedModel = createModel([ 'properties', 'properties-extended' ]);
+    var extensionModel = createModel([ 'extensions' ]);
 
 
     describe('data types', function() {
@@ -166,6 +167,39 @@ describe('Reader', function() {
         // then
         expect(warnings).to.be.empty;
         expect(rootElement).not.to.be.empty;
+      });
+
+
+      it('default <xml> namespace / any element', async function() {
+
+        // given
+        var reader = new Reader(extensionModel);
+        var rootHandler = reader.handler('e:Root');
+
+        var xml = '<e:root xmlns:e="http://extensions" xmlns:bar="http://bar" xml:lang="de">' +
+          '<bar:bar xml:lang="en" />' +
+        '</e:root>';
+
+        // when
+        var {
+          rootElement, warnings
+        } = await reader.fromXML(xml, rootHandler);
+
+        // then
+        expect(warnings).to.be.empty;
+        expect(rootElement).not.to.be.empty;
+
+        expect(rootElement.$attrs['xml:lang']).to.eql('de');
+
+        expect(rootElement).to.jsonEqual({
+          $type: 'e:Root',
+          extensions: [
+            {
+              $type: 'bar:bar',
+              'xml:lang': 'en'
+            }
+          ]
+        });
       });
 
 

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1751,6 +1751,32 @@ describe('Writer', function() {
     });
 
 
+    it('should strip xml namespace', function() {
+
+      // given
+      var writer = createWriter(extensionModel);
+
+      var root = extensionModel.create('e:Root', {
+        'xml:lang': 'de',
+        extensions: [
+          extensionModel.createAny('bar:bar', 'http://bar', {
+            'xml:lang': 'en'
+          })
+        ]
+      });
+
+      // when
+      var xml = writer.toXML(root);
+
+      // then
+      expect(xml).to.eql(
+        '<e:root xmlns:e="http://extensions" xmlns:bar="http://bar" xml:lang="de">' +
+          '<bar:bar xml:lang="en" />' +
+        '</e:root>'
+      );
+    });
+
+
     it('should keep local override', function() {
 
       // given


### PR DESCRIPTION
Our previous logic accounted for `xml` declarations in wellknown elements only. This PR fixes the issue to properly handle (and ignore on serialization) `xml` namespaced attributes.

Closes https://github.com/bpmn-io/moddle-xml/issues/60