### PR TITLE
add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
     "distro": "run-s build test:build",
     "build": "rollup -c",
+    "prepare": "npm run build",
     "test:build": "mocha --reporter=spec --recursive test/distro",
     "prepublishOnly": "run-s distro"
   },


### PR DESCRIPTION
Allow this package to be installed from a git repository instead of the npm registry. The script will run upon local "npm install".

Without a prepare script, only repository files are installed into node_modules/moddle. Folder dist/ is missing because no build process was executed and the package cannot be used.

See also: [moddle PR #33](https://github.com/bpmn-io/moddle/pull/33)