### PR TITLE
feat: support old style <idref> referencing

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -215,11 +215,19 @@ ReferenceHandler.prototype.handleNode = function(node) {
     this.element = this.createReference(node);
   }
 
+  const property = this.property;
+
+  const idAttr = property.xml && property.xml.idAttr;
+
+  if (idAttr && node.attributes[idAttr]) {
+    this.element.id = node.attributes[idAttr];
+  }
+
   return this;
 };
 
 ReferenceHandler.prototype.handleEnd = function() {
-  this.element.id = this.body;
+  this.element.id = this.element.id || this.body;
 };
 
 ReferenceHandler.prototype.createReference = function(node) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -245,16 +245,31 @@ function ReferenceSerializer(tagName) {
   this.tagName = tagName;
 }
 
-ReferenceSerializer.prototype.build = function(element) {
+ReferenceSerializer.prototype.build = function(property, element) {
+  this.property = property;
   this.element = element;
+
   return this;
 };
 
 ReferenceSerializer.prototype.serializeTo = function(writer) {
-  writer
-    .appendIndent()
-    .append('<' + this.tagName + '>' + this.element.id + '</' + this.tagName + '>')
-    .appendNewLine();
+
+  const property = this.property;
+
+  const idAttr = property.xml && property.xml.idAttr;
+
+  const id = this.element.id;
+  const tagName = this.tagName;
+
+  writer.appendIndent();
+
+  if (idAttr) {
+    writer.append('<' + tagName + ' ' + idAttr + '="' + id + '" />');
+  } else {
+    writer.append('<' + tagName + '>' + id + '</' + tagName + '>');
+  }
+
+  writer.appendNewLine();
 };
 
 function BodySerializer() {}
@@ -532,7 +547,7 @@ ElementSerializer.prototype.parseContainments = function(properties) {
     } else
     if (isReference) {
       forEach(value, function(v) {
-        body.push(new ReferenceSerializer(self.addTagName(self.nsPropertyTagName(p))).build(v));
+        body.push(new ReferenceSerializer(self.addTagName(self.nsPropertyTagName(p))).build(p, v));
       });
     } else {
 

--- a/test/fixtures/model/properties.json
+++ b/test/fixtures/model/properties.json
@@ -178,6 +178,20 @@
       ]
     },
     {
+      "name": "ReferencingNestedRef",
+      "superClass": [ "BaseWithId" ],
+      "properties": [
+        {
+          "name": "referencedComplex",
+          "type": "Complex",
+          "isReference": true,
+          "xml": {
+            "idAttr": "idref"
+          }
+        }
+      ]
+    },
+    {
       "name": "ReferencingCollection",
       "superClass": [ "BaseWithId" ],
       "properties": [

--- a/test/spec/reader.js
+++ b/test/spec/reader.js
@@ -878,6 +878,53 @@ describe('Reader', function() {
       });
 
 
+      it('single (attribute / idAttr)', async function() {
+
+        // given
+        var reader = new Reader(extendedModel);
+        var rootHandler = reader.handler('props:Root');
+
+        var xml =
+          '<props:root xmlns:props="http://properties">' +
+            '<props:containedCollection id="C_5">' +
+              '<props:complex id="C_1" />' +
+              '<props:complex id="C_2" />' +
+            '</props:containedCollection>' +
+            '<props:referencingNestedRef id="C_4">' +
+              '<props:referencedComplex idref="C_1" />' +
+            '</props:referencingNestedRef>' +
+            '<props:referencingNestedRef id="C_6" referencedComplex="C_1" />' +
+          '</props:root>';
+
+        // when
+        var {
+          rootElement
+        } = await reader.fromXML(xml, rootHandler);
+
+        // then
+        expect(rootElement).to.jsonEqual({
+          $type: 'props:Root',
+          any: [
+            {
+              $type: 'props:ContainedCollection',
+              id: 'C_5',
+              children: [
+                { $type: 'props:Complex', id: 'C_1' },
+                { $type: 'props:Complex', id: 'C_2' }
+              ]
+            },
+            { $type: 'props:ReferencingNestedRef', id: 'C_4' },
+            { $type: 'props:ReferencingNestedRef', id: 'C_6' }
+          ]
+        });
+
+        var referenced = rootElement.any[0].children[0];
+
+        expect(rootElement.any[1].referencedComplex).to.equal(referenced);
+        expect(rootElement.any[2].referencedComplex).to.equal(referenced);
+      });
+
+
       it('collection', async function() {
 
         // given

--- a/test/spec/rountrip.js
+++ b/test/spec/rountrip.js
@@ -455,6 +455,58 @@ describe('Roundtrip', function() {
   });
 
 
+  describe('references (idAttr)', function() {
+
+    var refsModel = createModel([ 'properties', 'properties-extended' ]);
+
+
+    it('single (attribute / idAttr)', async function() {
+
+      // given
+      var reader = new Reader(refsModel);
+      var rootHandler = reader.handler('props:Root');
+
+      var input =
+        '<props:root xmlns:props="http://properties">' +
+          '<props:containedCollection id="C_5">' +
+            '<props:complex id="C_1" />' +
+            '<props:complex id="C_2" />' +
+          '</props:containedCollection>' +
+          '<props:referencingNestedRef id="C_4">' +
+            '<props:referencedComplex idref="C_1" />' +
+          '</props:referencingNestedRef>' +
+          '<props:referencingNestedRef id="C_6" referencedComplex="C_1" />' +
+        '</props:root>';
+
+      var {
+        rootElement
+      } = await reader.fromXML(input, rootHandler);
+
+      // when
+      var writer = createWriter(refsModel);
+
+      var output = writer.toXML(rootElement);
+
+      // then
+      expect(output).to.eql(
+        '<props:root xmlns:props="http://properties">' +
+          '<props:containedCollection id="C_5">' +
+            '<props:complex id="C_1" />' +
+            '<props:complex id="C_2" />' +
+          '</props:containedCollection>' +
+          '<props:referencingNestedRef id="C_4">' +
+            '<props:referencedComplex idref="C_1" />' +
+          '</props:referencingNestedRef>' +
+          '<props:referencingNestedRef id="C_6">' +
+            '<props:referencedComplex idref="C_1" />' +
+          '</props:referencingNestedRef>' +
+        '</props:root>'
+      );
+    });
+
+  });
+
+
   describe('package owned xml -> serialize property', function() {
 
     it('should roundtrip', async function() {


### PR DESCRIPTION
Allows us to read and write references in nested element stub (with a dedicated `idAttr`). Improves our existing way to reference elements in an element.

#### Current `body` reference parsing

```xml
<sequenceFlow>
  <target>TARGET_ID</target>
</sequenceFlow>
```

#### Supporting UML / DMN 1.5 meta-model style of reference via stub elements

```xml
<sequenceFlow>
  <target idref="TARGET_ID" />
</sequenceFlow>
```