### PR TITLE
Changes `Moddle` class import from `moddle` lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install --save moddle-xml
 Create a [moddle instance](https://github.com/bpmn-io/moddle)
 
 ```javascript
-import Moddle from 'moddle';
+import { Moddle } from 'moddle';
 import {
   Reader,
   Writer


### PR DESCRIPTION
## Explanation:

If the developer tries to import the `Moddle` class as the default import, he'll get an error: `TypeError: Moddle is not a constructor`. Because in new versions of [`moddle`](https://github.com/bpmn-io/moddle) lib [you should import it in another way](https://github.com/bpmn-io/moddle#instantiate-moddle). Such as:

```js
import { Moddle } from 'moddle';
```
