### PR TITLE
safe access for $descriptor in writer

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -308,6 +308,13 @@ function ElementSerializer(parent, propertyDescriptor) {
 ElementSerializer.prototype.build = function(element) {
   this.element = element;
 
+  // make element property access safe
+  if (!element?.$descriptor) {
+    // eslint-disable-next-line no-undef
+    typeof console !== 'undefined' && console.warn(`missing $descriptor for ${element}`);
+    return this;
+  }
+
   var elementDescriptor = element.$descriptor,
       propertyDescriptor = this.propertyDescriptor;
 
@@ -416,7 +423,11 @@ ElementSerializer.prototype.parseGenericContainments = function(element) {
 
   if (children) {
     forEach(children, child => {
-      this.body.push(new ElementSerializer(this).build(child));
+      var serialized = new ElementSerializer(this).build(child);
+
+      if (serialized.tagName) {
+        this.body.push(serialized);
+      }
     });
   }
 };
@@ -551,7 +562,11 @@ ElementSerializer.prototype.parseContainments = function(properties) {
           serializer = new ElementSerializer(self);
         }
 
-        body.push(serializer.build(v));
+        var serialized = serializer.build(v);
+
+        if (serialized.tagName) {
+          body.push(serialized);
+        }
       });
     }
   });

--- a/test/spec/writer.js
+++ b/test/spec/writer.js
@@ -1174,6 +1174,32 @@ describe('Writer', function() {
       expect(xml).to.eql(expectedXml);
     });
 
+    it('missing $descriptor', function() {
+
+      // given
+      var model = createModel([ 'properties' ]);
+
+      var writer = new Writer({ preamble: true });
+      var root = model.create('props:Root');
+
+      root.get('any').push(model.create('props:Attributes'));
+
+      // force set $descriptor property for test purposes
+      Object.defineProperty(root.any[0], '$descriptor', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+        enumerable: true
+      });
+
+      // when
+      var xml = writer.toXML(root);
+
+      // then
+      expect(xml).to.eql(
+        '<?xml version="1.0" encoding="UTF-8"?>\n' +
+          '<props:root xmlns:props="http://properties" />');
+    });
   });
 
 


### PR DESCRIPTION
### Proposed Changes

- ensures safe access of `$descriptor` prior to accessing it
- "`$descriptor` is key to understand the shape of an object (and its serialization) it _must_ be present" 
- therefore, if it is not present, the element should not be serialized


## Issue
Addresses https://github.com/bpmn-io/moddle-xml/issues/77
